### PR TITLE
DefaultRandomStringProvider.GetRandomString() bugfixed

### DIFF
--- a/src/Server/Bit.Owin/Implementations/DefaultRandomStringProvider.cs
+++ b/src/Server/Bit.Owin/Implementations/DefaultRandomStringProvider.cs
@@ -15,7 +15,7 @@ namespace Bit.Owin.Implementations
                 result += Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
             }
 
-            return result.Substring(length);
+            return result.Substring(0, length);
         }
     }
 }


### PR DESCRIPTION
#112 